### PR TITLE
Use earl to test earl

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "clean": "rm -rf dist",
     "build": "tsc -p ./tsconfig.prod.json",
     "build:watch": "tsc -p ./tsconfig.prod.json --watch",
+    "build:watch:tests": "tsc -p ./tsconfig.json --watch",
     "test": "mocha --config ./test/.mocharc.js",
     "test:fix": "yarn lint:fix && yarn format:fix && yarn test && yarn typecheck",
     "prepublishOnly": "yarn lint && yarn format && yarn test && yarn typecheck && yarn build"

--- a/src/matchers/A.ts
+++ b/src/matchers/A.ts
@@ -21,6 +21,8 @@ export type Class2Primitive<T> = T extends String
   ? bigint
   : T extends Symbol
   ? symbol
+  : T extends Function
+  ? any
   : T extends Exact<Object, T>
   ? any
   : T

--- a/test/ExecutionCtx.test.ts
+++ b/test/ExecutionCtx.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import sinon from 'sinon'
 
+import { expect as expectEarl } from '../src'
 import { ExecutionCtx } from '../src/ExecutionCtx'
 
 describe('ExecutionCtx', () => {
@@ -12,7 +13,7 @@ describe('ExecutionCtx', () => {
     const executionCtx = new ExecutionCtx()
     executionCtx.registerMock(mockMock as any)
 
-    expect(() => executionCtx.verifyAllMocks()).not.to.throw()
+    expectEarl(() => executionCtx.verifyAllMocks()).not.toThrow()
     expect(mockMock.isExhausted).to.be.calledOnceWithExactly()
   })
 
@@ -25,7 +26,7 @@ describe('ExecutionCtx', () => {
     executionCtx.registerMock(mockMock as any)
     executionCtx.reset()
 
-    expect(() => executionCtx.verifyAllMocks()).not.to.throw()
+    expectEarl(() => executionCtx.verifyAllMocks()).not.toThrow()
     expect(mockMock.isExhausted).not.to.be.called
   })
 })

--- a/test/Expectation.test.ts
+++ b/test/Expectation.test.ts
@@ -1,6 +1,6 @@
-import { expect } from 'chai'
 import sinon from 'sinon'
 
+import { expect as expectEarl } from '../src'
 import { Expectation } from '../src/Expectation'
 
 describe('assert', () => {
@@ -11,11 +11,11 @@ describe('assert', () => {
     const expectation = new Expectation(sinon.spy(), undefined)
 
     it('doesnt throw when validation was successful', () => {
-      expect(() => expectation['assert'](success)).not.to.throw()
+      expectEarl(() => expectation['assert'](success)).not.toThrow()
     })
 
     it('throws when validation was unsuccessful', () => {
-      expect(() => expectation['assert'](failure)).to.throw('Failure')
+      expectEarl(() => expectation['assert'](failure)).toThrow(expectEarl.error('Failure'))
     })
   })
 
@@ -23,11 +23,11 @@ describe('assert', () => {
     const expectation = new Expectation(sinon.spy(), undefined).not
 
     it('throws when validation was successful', () => {
-      expect(() => expectation['assert'](success)).to.throw('Negated failure')
+      expectEarl(() => expectation['assert'](success)).toThrow(expectEarl.error('Negated failure'))
     })
 
     it('doesnt throw when validation was unsuccessful', () => {
-      expect(() => expectation['assert'](failure)).not.to.throw()
+      expectEarl(() => expectation['assert'](failure)).not.toThrow()
     })
   })
 })

--- a/test/autofix/predicates.test.ts
+++ b/test/autofix/predicates.test.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai'
-
+import { expect as expectEarl } from '../../src'
 import { shouldPreventAutofix } from '../../src/autofix/predicates'
 
 describe('autofix > shouldPreventAutofix', () => {
@@ -7,12 +6,12 @@ describe('autofix > shouldPreventAutofix', () => {
     const dummyEnv = {
       CI: '1',
     }
-    expect(shouldPreventAutofix(dummyEnv)()).to.be.true
+    expectEarl(shouldPreventAutofix(dummyEnv)()).toEqual(true)
   })
 
   it(`doesn't prevent in normal situation`, () => {
     const dummyEnv = {}
 
-    expect(shouldPreventAutofix(dummyEnv)()).to.be.false
+    expectEarl(shouldPreventAutofix(dummyEnv)()).toEqual(false)
   })
 })

--- a/test/autofix/replaceCallInSource.test.ts
+++ b/test/autofix/replaceCallInSource.test.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai'
-
+import { expect as expectEarl } from '../../src'
 import { NoCallSiteError, OutOfFileError, replaceCallInSource } from '../../src/autofix/replaceCallInSource'
 
 describe('replaceCallInSource', () => {
@@ -11,7 +10,7 @@ console.log("Hello world");
     `
     const modifiedSource = replaceCallInSource({ source, line: 2, column: 15, call: 'toEqual', newArg: `'newValue'` })
 
-    expect(modifiedSource).to.eq(`
+    expectEarl(modifiedSource).toEqual(`
 console.log("Hello world");
 expect(result).toEqual('newValue');
 console.log("Hello world");
@@ -29,7 +28,7 @@ console.log("Hello world");
     `
     const modifiedSource = replaceCallInSource({ source, line: 3, column: 2, call: 'toEqual', newArg: `'newValue'` })
 
-    expect(modifiedSource).to.eq(`
+    expectEarl(modifiedSource).toEqual(`
 console.log("Hello world");
 expect(result).
   toEqual('newValue');
@@ -41,15 +40,15 @@ console.log("Hello world");
 
   it("throws when position doesn't point at source", () => {
     const source = `console.log("Hello world");`
-    expect(() => replaceCallInSource({ source, line: 2, column: 0, call: 'toEqual', newArg: `'newValue'` })).to.throw(
-      OutOfFileError,
-    )
+    expectEarl(() =>
+      replaceCallInSource({ source, line: 2, column: 0, call: 'toEqual', newArg: `'newValue'` }),
+    ).toThrow(expectEarl.error(OutOfFileError))
   })
 
   it("throws when position doesn't at expected function call", () => {
     const source = `expect(result).toEqual();`
-    expect(() => replaceCallInSource({ source, line: 0, column: 0, call: 'toEqual', newArg: `'newValue'` })).to.throw(
-      NoCallSiteError,
-    )
+    expectEarl(() =>
+      replaceCallInSource({ source, line: 0, column: 0, call: 'toEqual', newArg: `'newValue'` }),
+    ).toThrow(expectEarl.error(NoCallSiteError))
   })
 })

--- a/test/autofix/toLiteral.test.ts
+++ b/test/autofix/toLiteral.test.ts
@@ -1,14 +1,13 @@
-import { expect } from 'chai'
-
+import { expect as expectEarl } from '../../src'
 import { toLiteral } from '../../src/autofix/toLiteral'
 
 describe('toLiteral', () => {
   it('transforms primitive values', () => {
-    expect(toLiteral('abc')).to.be.deep.eq('"abc"')
-    expect(toLiteral(5)).to.be.deep.eq('5')
-    expect(toLiteral(true)).to.be.deep.eq('true')
-    expect(toLiteral(null)).to.be.deep.eq('null')
-    expect(toLiteral(undefined)).to.be.deep.eq('undefined')
+    expectEarl(toLiteral('abc')).toEqual('"abc"')
+    expectEarl(toLiteral(5)).toEqual('5')
+    expectEarl(toLiteral(true)).toEqual('true')
+    expectEarl(toLiteral(null)).toEqual('null')
+    expectEarl(toLiteral(undefined)).toEqual('undefined')
   })
 
   it('transforms objects', () => {
@@ -20,7 +19,7 @@ describe('toLiteral', () => {
       },
     }
 
-    expect(toLiteral(input)).to.be.deep.eq('{"abc":5,"nested":{"a":null,"c":5,},}')
+    expectEarl(toLiteral(input)).toEqual('{"abc":5,"nested":{"a":null,"c":5,},}')
   })
 
   it('transforms arrays', () => {
@@ -34,7 +33,7 @@ describe('toLiteral', () => {
       'a string',
     ]
 
-    expect(toLiteral(input)).to.be.deep.eq('[{"abc":5,"nested":{"a":null,},},"a string"]')
+    expectEarl(toLiteral(input)).toEqual('[{"abc":5,"nested":{"a":null,},},"a string"]')
   })
 
   it('transforms custom classes', () => {
@@ -43,13 +42,13 @@ describe('toLiteral', () => {
     }
     const input = new DummyClass(5)
 
-    expect(toLiteral(input)).to.be.deep.eq('expect.a(DummyClass)')
+    expectEarl(toLiteral(input)).toEqual('expect.a(DummyClass)')
   })
 
   it('transforms errors to error matcher', () => {
     const input = new Error('Goodbye cruel world!')
 
-    expect(toLiteral(input)).to.be.deep.eq('expect.error("Goodbye cruel world!")')
+    expectEarl(toLiteral(input)).toEqual('expect.error("Goodbye cruel world!")')
   })
 
   it.skip('prettifies output')

--- a/test/matchers/A.test.ts
+++ b/test/matchers/A.test.ts
@@ -1,83 +1,82 @@
-import { expect } from 'chai'
-
+import { expect as expectEarl } from '../../src'
 import { AMatcher } from '../../src/matchers/A'
 
 describe('A matcher', () => {
   it('should match string', () => {
     const m = new AMatcher(String)
 
-    expect(m.check('m')).to.be.true
+    expectEarl(m.check('m')).toEqual(true)
     // eslint-disable-next-line
-    expect(m.check(new String('green'))).to.be.true
+    expectEarl(m.check(new String('green'))).toEqual(true)
 
-    expect(m.check(undefined)).to.be.false
-    expect(m.check(null)).to.be.false
-    expect(m.check(1)).to.be.false
-    expect(m.check({})).to.be.false
+    expectEarl(m.check(undefined)).toEqual(false)
+    expectEarl(m.check(null)).toEqual(false)
+    expectEarl(m.check(1)).toEqual(false)
+    expectEarl(m.check({})).toEqual(false)
   })
 
   it('should match numbers', () => {
     const m = new AMatcher(Number)
 
-    expect(m.check(5)).to.be.true
+    expectEarl(m.check(5)).toEqual(true)
     // eslint-disable-next-line
-    expect(m.check(new Number(5))).to.be.true
+    expectEarl(m.check(new Number(5))).toEqual(true)
 
-    expect(m.check(NaN)).to.be.false
-    expect(m.check(undefined)).to.be.false
-    expect(m.check(null)).to.be.false
-    expect(m.check([])).to.be.false
-    expect(m.check({})).to.be.false
+    expectEarl(m.check(NaN)).toEqual(false)
+    expectEarl(m.check(undefined)).toEqual(false)
+    expectEarl(m.check(null)).toEqual(false)
+    expectEarl(m.check([])).toEqual(false)
+    expectEarl(m.check({})).toEqual(false)
   })
 
   it('should match boolean', () => {
     const m = new AMatcher(Boolean)
 
-    expect(m.check(true)).to.be.true
+    expectEarl(m.check(true)).toEqual(true)
     // eslint-disable-next-line
-    expect(m.check(new Boolean(false))).to.be.true
+    expectEarl(m.check(new Boolean(false))).toEqual(true)
 
-    expect(m.check(5)).to.be.false
-    expect(m.check(undefined)).to.be.false
-    expect(m.check(null)).to.be.false
-    expect(m.check([])).to.be.false
-    expect(m.check({})).to.be.false
+    expectEarl(m.check(5)).toEqual(false)
+    expectEarl(m.check(undefined)).toEqual(false)
+    expectEarl(m.check(null)).toEqual(false)
+    expectEarl(m.check([])).toEqual(false)
+    expectEarl(m.check({})).toEqual(false)
   })
 
   it('should match bigint', () => {
     const m = new AMatcher(BigInt)
 
-    expect(m.check(5n)).to.be.true
-    expect(m.check(BigInt(5))).to.be.true
+    expectEarl(m.check(5n)).toEqual(true)
+    expectEarl(m.check(BigInt(5))).toEqual(true)
 
-    expect(m.check(5)).to.be.false
-    expect(m.check(undefined)).to.be.false
-    expect(m.check(null)).to.be.false
-    expect(m.check([])).to.be.false
-    expect(m.check({})).to.be.false
+    expectEarl(m.check(5)).toEqual(false)
+    expectEarl(m.check(undefined)).toEqual(false)
+    expectEarl(m.check(null)).toEqual(false)
+    expectEarl(m.check([])).toEqual(false)
+    expectEarl(m.check({})).toEqual(false)
   })
 
   it('should match function', () => {
     const m = new AMatcher(Function)
 
-    expect(m.check(() => {})).to.be.true
+    expectEarl(m.check(() => {})).toEqual(true)
 
-    expect(m.check(undefined)).to.be.false
-    expect(m.check(null)).to.be.false
-    expect(m.check([])).to.be.false
-    expect(m.check({})).to.be.false
+    expectEarl(m.check(undefined)).toEqual(false)
+    expectEarl(m.check(null)).toEqual(false)
+    expectEarl(m.check([])).toEqual(false)
+    expectEarl(m.check({})).toEqual(false)
   })
 
   it('should match object', () => {
     const m = new AMatcher(Object)
 
-    expect(m.check({})).to.be.true
+    expectEarl(m.check({})).toEqual(true)
     // eslint-disable-next-line
-    expect(m.check(new Object({ m: 5 }))).to.be.true
-    expect(m.check([])).to.be.true
+    expectEarl(m.check(new Object({ m: 5 }))).toEqual(true)
+    expectEarl(m.check([])).toEqual(true)
 
-    expect(m.check(undefined)).to.be.false
-    expect(m.check(null)).to.be.false
+    expectEarl(m.check(undefined)).toEqual(false)
+    expectEarl(m.check(null)).toEqual(false)
   })
 
   it('should match symbol', () => {
@@ -85,22 +84,22 @@ describe('A matcher', () => {
     const m = new AMatcher(Symbol)
 
     // eslint-disable-next-line
-    expect(m.check(Symbol())).to.be.true
+    expectEarl(m.check(Symbol())).toEqual(true)
 
-    expect(m.check(undefined)).to.be.false
-    expect(m.check(null)).to.be.false
-    expect(m.check([])).to.be.false
-    expect(m.check({})).to.be.false
+    expectEarl(m.check(undefined)).toEqual(false)
+    expectEarl(m.check(null)).toEqual(false)
+    expectEarl(m.check([])).toEqual(false)
+    expectEarl(m.check({})).toEqual(false)
   })
 
   it('should match an array', () => {
     const m = new AMatcher(Array)
 
-    expect(m.check([])).to.be.true
+    expectEarl(m.check([])).toEqual(true)
 
-    expect(m.check(5)).to.be.false
-    expect(m.check(undefined)).to.be.false
-    expect(m.check(null)).to.be.false
-    expect(m.check({})).to.be.false
+    expectEarl(m.check(5)).toEqual(false)
+    expectEarl(m.check(undefined)).toEqual(false)
+    expectEarl(m.check(null)).toEqual(false)
+    expectEarl(m.check({})).toEqual(false)
   })
 })

--- a/test/matchers/Anything.test.ts
+++ b/test/matchers/Anything.test.ts
@@ -1,15 +1,14 @@
-import { expect } from 'chai'
-
+import { expect as expectEarl } from '../../src'
 import { AnythingMatcher } from '../../src/matchers/Anything'
 
 describe('Anything matcher', () => {
   it('should match anything', () => {
     const m = new AnythingMatcher()
 
-    expect(m.check('a')).to.be.true
-    expect(m.check(undefined)).to.be.true
-    expect(m.check(1)).to.be.true
-    expect(m.check({})).to.be.true
-    expect(m.check([])).to.be.true
+    expectEarl(m.check('a')).toEqual(true)
+    expectEarl(m.check(undefined)).toEqual(true)
+    expectEarl(m.check(1)).toEqual(true)
+    expectEarl(m.check({})).toEqual(true)
+    expectEarl(m.check([])).toEqual(true)
   })
 })

--- a/test/matchers/Error.test.ts
+++ b/test/matchers/Error.test.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai'
-
+import { expect as expectEarl } from '../../src'
 import { ErrorMatcher } from '../../src/matchers/Error'
 import { StringMatchingMatcher } from '../../src/matchers/StringMatching'
 
@@ -7,31 +6,31 @@ describe('Error matcher', () => {
   it('matches any errors when no msgs was provided', () => {
     const m = new ErrorMatcher(Error)
 
-    expect(m.check(new Error('bye world'))).to.be.true
+    expectEarl(m.check(new Error('bye world'))).toEqual(true)
   })
 
   it('matches errors with msgs', () => {
     const m = new ErrorMatcher(Error, 'bye world')
 
-    expect(m.check(new Error('bye world'))).to.be.true
+    expectEarl(m.check(new Error('bye world'))).toEqual(true)
   })
 
   it('doesnt match errors with different msgs', () => {
     const m = new ErrorMatcher(Error, 'bye world')
 
-    expect(m.check(new Error('hello world'))).to.be.false
+    expectEarl(m.check(new Error('hello world'))).toEqual(false)
   })
 
   it('doesnt match non-errors', () => {
     const m = new ErrorMatcher(Error, 'bye world')
 
-    expect(m.check('123')).to.be.false
+    expectEarl(m.check('123')).toEqual(false)
   })
 
   it('matches errors with matchers', () => {
     const m = new ErrorMatcher(Error, StringMatchingMatcher.make('world'))
 
-    expect(m.check(new Error('hello world'))).to.be.true
+    expectEarl(m.check(new Error('hello world'))).toEqual(true)
   })
 
   describe('with custom error class', () => {
@@ -44,25 +43,25 @@ describe('Error matcher', () => {
     it('matches custom error classes', () => {
       const m = new ErrorMatcher(HttpError)
 
-      expect(m.check(new HttpError(500))).to.be.true
+      expectEarl(m.check(new HttpError(500))).toEqual(true)
     })
 
     it('matches custom error classes with error messages', () => {
       const m = new ErrorMatcher(HttpError, 'Http Error: 500')
 
-      expect(m.check(new HttpError(500))).to.be.true
+      expectEarl(m.check(new HttpError(500))).toEqual(true)
     })
 
     it('doesnt match when custom error classes are different', () => {
       const m = new ErrorMatcher(HttpError)
 
-      expect(m.check(new Error('500'))).to.be.false
+      expectEarl(m.check(new Error('500'))).toEqual(false)
     })
 
     it('doesnt match custom error classes with mismatched error messages', () => {
       const m = new ErrorMatcher(HttpError, 'Http Error: 501')
 
-      expect(m.check(new HttpError(500))).to.be.false
+      expectEarl(m.check(new HttpError(500))).toEqual(false)
     })
   })
 })

--- a/test/matchers/NumberCloseTo.test.ts
+++ b/test/matchers/NumberCloseTo.test.ts
@@ -1,40 +1,39 @@
-import { expect } from 'chai'
-
+import { expect as expectEarl } from '../../src'
 import { NumberCloseToMatcher } from '../../src/matchers/NumberCloseTo'
 
 describe('NumberCloseTo matcher', () => {
   it('matches numbers in within delta', () => {
     const m = new NumberCloseToMatcher(42, 5)
 
-    expect(m.check(37)).to.be.true
-    expect(m.check(47)).to.be.true
-    expect(m.check(43)).to.be.true
-    expect(m.check(46)).to.be.true
+    expectEarl(m.check(37)).toEqual(true)
+    expectEarl(m.check(47)).toEqual(true)
+    expectEarl(m.check(43)).toEqual(true)
+    expectEarl(m.check(46)).toEqual(true)
   })
 
   it('matches numbers in within small delta', () => {
     const m = new NumberCloseToMatcher(42, 1)
 
-    expect(m.check(42.01)).to.be.true
+    expectEarl(m.check(42.01)).toEqual(true)
   })
 
   it('matches exact numbers', () => {
     const m = new NumberCloseToMatcher(42, 5)
 
-    expect(m.check(42)).to.be.true
+    expectEarl(m.check(42)).toEqual(true)
   })
 
   it('doesnt match numbers outside delta', () => {
     const m = new NumberCloseToMatcher(42, 1)
 
-    expect(m.check(44)).to.be.false
-    expect(m.check(40)).to.be.false
+    expectEarl(m.check(44)).toEqual(false)
+    expectEarl(m.check(40)).toEqual(false)
   })
 
   it('doesnt match non-numbers', () => {
     const m = new NumberCloseToMatcher(42, 1)
 
-    expect(m.check('a')).to.be.false
-    expect(m.check(undefined)).to.be.false
+    expectEarl(m.check('a')).toEqual(false)
+    expectEarl(m.check(undefined)).toEqual(false)
   })
 })

--- a/test/matchers/StringMatching.test.ts
+++ b/test/matchers/StringMatching.test.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai'
-
+import { expect as expectEarl } from '../../src'
 import { StringMatchingMatcher } from '../../src/matchers/StringMatching'
 
 describe('StringContaining matcher', () => {
@@ -7,25 +6,25 @@ describe('StringContaining matcher', () => {
     it('matches strings containing substring', () => {
       const m = new StringMatchingMatcher('test')
 
-      expect(m.check('abc test cde')).to.be.true
-      expect(m.check('testtesttest')).to.be.true
+      expectEarl(m.check('abc test cde')).toEqual(true)
+      expectEarl(m.check('testtesttest')).toEqual(true)
     })
 
     it('doesnt match non-strings', () => {
       const m = new StringMatchingMatcher('test')
 
-      expect(m.check(undefined)).to.be.false
-      expect(m.check(1)).to.be.false
-      expect(m.check({})).to.be.false
-      expect(m.check([])).to.be.false
+      expectEarl(m.check(undefined)).toEqual(false)
+      expectEarl(m.check(1)).toEqual(false)
+      expectEarl(m.check({})).toEqual(false)
+      expectEarl(m.check([])).toEqual(false)
     })
 
     it('doesnt match strings not containing substring', () => {
       const m = new StringMatchingMatcher('test')
 
-      expect(m.check('')).to.be.false
-      expect(m.check('tes')).to.be.false
-      expect(m.check('abc-acbc')).to.be.false
+      expectEarl(m.check('')).toEqual(false)
+      expectEarl(m.check('tes')).toEqual(false)
+      expectEarl(m.check('abc-acbc')).toEqual(false)
     })
   })
 
@@ -33,25 +32,25 @@ describe('StringContaining matcher', () => {
     it('matches strings matching pattern', () => {
       const m = new StringMatchingMatcher(new RegExp('^[0-9]+$'))
 
-      expect(m.check('1323')).to.be.true
-      expect(m.check('1')).to.be.true
+      expectEarl(m.check('1323')).toEqual(true)
+      expectEarl(m.check('1')).toEqual(true)
     })
 
     it('doesnt match non-strings', () => {
       const m = new StringMatchingMatcher(new RegExp('^[0-9]+$'))
 
-      expect(m.check(undefined)).to.be.false
-      expect(m.check(1)).to.be.false
-      expect(m.check({})).to.be.false
-      expect(m.check([])).to.be.false
+      expectEarl(m.check(undefined)).toEqual(false)
+      expectEarl(m.check(1)).toEqual(false)
+      expectEarl(m.check({})).toEqual(false)
+      expectEarl(m.check([])).toEqual(false)
     })
 
     it('doesnt match strings not matching pattern', () => {
       const m = new StringMatchingMatcher(new RegExp('^[0-9]+$'))
 
-      expect(m.check('')).to.be.false
-      expect(m.check('tes')).to.be.false
-      expect(m.check('123a')).to.be.false
+      expectEarl(m.check('')).toEqual(false)
+      expectEarl(m.check('tes')).toEqual(false)
+      expectEarl(m.check('123a')).toEqual(false)
     })
   })
 })

--- a/test/mocks/looseMock.test.ts
+++ b/test/mocks/looseMock.test.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai'
-
+import { expect as expectEarl } from '../../src'
 import { looseMockFn } from '../../src/mocks/looseMock'
 
 describe('looseMock', () => {
@@ -7,37 +6,37 @@ describe('looseMock', () => {
     it('works', () => {
       const mock = looseMockFn(() => 42)
 
-      expect(mock(1)).to.be.eq(42)
-      expect(mock(2)).to.be.eq(42)
-      expect(mock()).to.be.eq(42)
+      expectEarl(mock(1)).toEqual(42)
+      expectEarl(mock(2)).toEqual(42)
+      expectEarl(mock()).toEqual(42)
 
-      expect(mock.calls).to.be.deep.eq([[1], [2], []])
+      expectEarl(mock.calls).toEqual([[1], [2], []])
     })
   })
 
   describe('mockFn()', () => {
     it('creates a function', () => {
       const fn = looseMockFn(() => {})
-      expect(fn).to.be.instanceOf(Function)
+      expectEarl(fn).toEqual(expectEarl.a(Function))
     })
 
     it('function returns whatever default impl returns', () => {
       const fn = looseMockFn(() => undefined)
 
-      expect(fn()).to.equal(undefined)
+      expectEarl(fn()).toEqual(undefined)
     })
   })
 
   describe('.calls', () => {
     it('is empty at first', () => {
       const fn = looseMockFn(() => 5)
-      expect(fn.calls).to.deep.equal([])
+      expectEarl(fn.calls).toEqual([])
     })
 
     it('stores a single call', () => {
       const fn = looseMockFn(() => {})
       fn()
-      expect(fn.calls).to.deep.equal([[]])
+      expectEarl(fn.calls).toEqual([[]])
     })
 
     it('stores multiple calls', () => {
@@ -45,7 +44,7 @@ describe('looseMock', () => {
       fn()
       fn(1)
       fn(5, 'yo')
-      expect(fn.calls).to.deep.equal([[], [1], [5, 'yo']])
+      expectEarl(fn.calls).toEqual([[], [1], [5, 'yo']])
     })
 
     it('respects .throws', () => {
@@ -56,7 +55,7 @@ describe('looseMock', () => {
       try {
         fn()
       } catch {}
-      expect(fn.calls).to.deep.equal([[]])
+      expectEarl(fn.calls).toEqual([[]])
     })
   })
 })

--- a/test/mocks/strictMock.test.ts
+++ b/test/mocks/strictMock.test.ts
@@ -1,6 +1,4 @@
-import { expect } from 'chai'
-
-import { expect as earl } from '../../src'
+import { expect as earl, expect as expectEarl } from '../../src'
 import { mockFn } from '../../src/mocks/strictMock'
 
 describe('strictMock', () => {
@@ -12,24 +10,24 @@ describe('strictMock', () => {
       mock.expectedCall([2]).returns('b')
       mock.expectedCall([earl.a(Number)]).returns('c')
 
-      expect(mock(1)).to.be.eq('a')
-      expect(mock(2)).to.be.eq('b')
-      expect(mock(5)).to.be.eq('c')
-      expect(() => mock(3)).to.throw('Unexpected call!')
-      expect(() => earl(mock).toBeExhausted()).not.to.throw()
+      expectEarl(mock(1)).toEqual('a')
+      expectEarl(mock(2)).toEqual('b')
+      expectEarl(mock(5)).toEqual('c')
+      expectEarl(() => mock(3)).toThrow(expectEarl.error('Unexpected call! Called with [3]'))
+      expectEarl(() => earl(mock).toBeExhausted()).not.toThrow()
     })
   })
 
   describe('mockFn()', () => {
     it('creates a function', () => {
       const fn = mockFn<[], void>()
-      expect(fn).to.be.instanceOf(Function)
+      expectEarl(fn).toEqual(expectEarl.a(Function))
     })
 
     it('function throws by default', () => {
       const fn = mockFn<[], void>()
 
-      expect(() => fn()).to.throw('Unexpected call! Called with []')
+      expectEarl(() => fn()).toThrow(expectEarl.error('Unexpected call! Called with []'))
     })
   })
 
@@ -37,16 +35,18 @@ describe('strictMock', () => {
     it('supports .returns', () => {
       const fn = mockFn<[number, number], number>().expectedCall([1, 2]).returns(3)
 
-      expect(() => fn(2, 2)).to.throw('Unexpected call! Expected [1, 2] but was called with [2, 2]')
-      expect(fn(1, 2)).to.equal(3)
-      expect(() => fn(2, 2)).to.throw('Unexpected call! Called with [2, 2]')
+      expectEarl(() => fn(2, 2)).toThrow(
+        expectEarl.error('Unexpected call! Expected [1, 2] but was called with [2, 2]'),
+      )
+      expectEarl(fn(1, 2)).toEqual(3)
+      expectEarl(() => fn(2, 2)).toThrow(expectEarl.error('Unexpected call! Called with [2, 2]'))
     })
 
     it('supports .throws', () => {
       const fn = mockFn<[number, number], number>().expectedCall([1, 2]).throws(new Error('Boom'))
 
-      expect(() => fn(1, 2)).to.throw('Boom')
-      expect(() => fn(2, 2)).to.throw('Unexpected call! Called with [2, 2]')
+      expectEarl(() => fn(1, 2)).toThrow(expectEarl.error('Boom'))
+      expectEarl(() => fn(2, 2)).toThrow(expectEarl.error('Unexpected call! Called with [2, 2]'))
     })
 
     it('supports .executes', () => {
@@ -54,8 +54,8 @@ describe('strictMock', () => {
         .expectedCall([1, 2])
         .executes((a, b) => a + b)
 
-      expect(fn(1, 2)).to.equal(3)
-      expect(() => fn(2, 2)).to.throw('Unexpected call! Called with [2, 2]')
+      expectEarl(fn(1, 2)).toEqual(3)
+      expectEarl(() => fn(2, 2)).toThrow(expectEarl.error('Unexpected call! Called with [2, 2]'))
     })
 
     it('supports matchers', () => {
@@ -63,25 +63,25 @@ describe('strictMock', () => {
         .expectedCall([earl.a(Number)])
         .returns(3)
 
-      expect(fn(420)).to.equal(3)
-      expect(() => fn(2)).to.throw('Unexpected call! Called with [2]')
+      expectEarl(fn(420)).toEqual(3)
+      expectEarl(() => fn(2)).toThrow(expectEarl.error('Unexpected call! Called with [2]'))
     })
   })
 
   describe('.isExhausted', () => {
     it('returns true initially', () => {
       const fn = mockFn<[number], number>()
-      expect(fn.isExhausted()).to.equal(true)
+      expectEarl(fn.isExhausted()).toEqual(true)
     })
 
     it('returns false if there are queued calls', () => {
       const fn = mockFn<[number], number>().expectedCall([3]).returns(0)
 
-      expect(fn.isExhausted()).to.equal(false)
+      expectEarl(fn.isExhausted()).toEqual(false)
 
       fn(3)
 
-      expect(fn.isExhausted()).to.equal(true)
+      expectEarl(fn.isExhausted()).toEqual(true)
     })
   })
 })

--- a/test/validators/mocks/toBeExhausted.test.ts
+++ b/test/validators/mocks/toBeExhausted.test.ts
@@ -1,6 +1,4 @@
-import { expect } from 'chai'
-
-import { expect as earl } from '../../../src'
+import { expect as earl, expect as expectEarl } from '../../../src'
 import { mockFn } from '../../../src/mocks/strictMock'
 
 describe('toBeExhausted', () => {
@@ -8,14 +6,14 @@ describe('toBeExhausted', () => {
     it('works with exhausted mocks', () => {
       const mock = mockFn()
 
-      expect(() => earl(mock).toBeExhausted()).not.to.throw()
+      expectEarl(() => earl(mock).toBeExhausted()).not.toThrow()
     })
 
     it('throws with exhausted mocks', () => {
       const mock = mockFn<[number], number>()
       mock.expectedCall([1]).returns(1)
 
-      expect(() => earl(mock).toBeExhausted()).to.throw('Mock not exhausted!')
+      expectEarl(() => earl(mock).toBeExhausted()).toThrow(expectEarl.error('Mock not exhausted!'))
     })
   })
 
@@ -23,14 +21,14 @@ describe('toBeExhausted', () => {
     it('throws with exhausted mocks', () => {
       const mock = mockFn()
 
-      expect(() => earl(mock).not.toBeExhausted()).to.throw('Mock exhausted!')
+      expectEarl(() => earl(mock).not.toBeExhausted()).toThrow(expectEarl.error('Mock exhausted!'))
     })
 
     it('works with exhausted mocks', () => {
       const mock = mockFn<[number], number>()
       mock.expectedCall([1]).returns(1)
 
-      expect(() => earl(mock).not.toBeExhausted()).not.to.throw()
+      expectEarl(() => earl(mock).not.toBeExhausted()).not.toThrow()
     })
   })
 })

--- a/test/validators/mocks/toHaveBeenCalledWith.test.ts
+++ b/test/validators/mocks/toHaveBeenCalledWith.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 
-import { expect as earl } from '../../../src'
+import { expect as earl, expect as expectEarl } from '../../../src'
 import { looseMockFn } from '../../../src/mocks/looseMock'
 
 describe('toHaveBeenCalledWith', () => {
@@ -10,7 +10,7 @@ describe('toHaveBeenCalledWith', () => {
 
       mock(1, 2, 3)
 
-      expect(() => earl(mock).toHaveBeenCalledWith([1, 2, 3])).not.to.throw()
+      expectEarl(() => earl(mock).toHaveBeenCalledWith([1, 2, 3])).not.toThrow()
     })
 
     it('works with matchers', () => {
@@ -18,7 +18,7 @@ describe('toHaveBeenCalledWith', () => {
 
       mock(1, 2, 3)
 
-      expect(() => earl(mock).toHaveBeenCalledWith([1, 2, earl.a(Number)])).not.to.throw()
+      expectEarl(() => earl(mock).toHaveBeenCalledWith([1, 2, earl.a(Number)])).not.toThrow()
     })
 
     it('throws on partial matches', () => {
@@ -34,7 +34,9 @@ describe('toHaveBeenCalledWith', () => {
     it('throws with empty mocks', () => {
       const mock = looseMockFn(() => {})
 
-      expect(() => earl(mock).toHaveBeenCalledWith([])).to.throw('Mock was not called with [] but was expected to')
+      expectEarl(() => earl(mock).toHaveBeenCalledWith([])).toThrow(
+        expectEarl.error('Mock was not called with [] but was expected to'),
+      )
     })
   })
 
@@ -54,13 +56,13 @@ describe('toHaveBeenCalledWith', () => {
 
       mock(1, 2, 3)
 
-      expect(() => earl(mock).not.toHaveBeenCalledWith([1, 2])).not.to.throw()
+      expectEarl(() => earl(mock).not.toHaveBeenCalledWith([1, 2])).not.toThrow()
     })
 
     it('works with empty mocks', () => {
       const mock = looseMockFn(() => {})
 
-      expect(() => earl(mock).not.toHaveBeenCalledWith([])).not.to.throw()
+      expectEarl(() => earl(mock).not.toHaveBeenCalledWith([])).not.toThrow()
     })
   })
 })

--- a/test/validators/toBeRejected.test.ts
+++ b/test/validators/toBeRejected.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { spy } from 'sinon'
 
-import { expect as earl } from '../../src'
+import { expect as earl, expect as expectEarl } from '../../src'
 import { Expectation } from '../../src/Expectation'
 
 describe('toBeRejected', () => {
@@ -15,22 +15,22 @@ describe('toBeRejected', () => {
     it('throws on msg mismatch', async () => {
       const run = earl(Promise.reject(new Error('Test msg'))).toBeRejected(earl.error('Dummy msg'))
 
-      await expect(run).to.be.eventually.rejectedWith(
-        'Expected to be rejected with "Error: Dummy msg" but got "Error: Test msg"',
+      await expectEarl(run).toBeRejected(
+        expectEarl.error('Expected to be rejected with "Error: Dummy msg" but got "Error: Test msg"'),
       )
     })
 
     it('works when negated', async () => {
       const run = earl(Promise.reject(new Error('Test msg'))).not.toBeRejected(earl.error('Dummy msg'))
 
-      await expect(run).not.to.be.eventually.rejected
+      await expectEarl(run).not.toBeRejected()
     })
 
     it('throws when negated and msg match', async () => {
       const run = earl(Promise.reject(new Error('Test msg'))).not.toBeRejected(earl.error('Test msg'))
 
-      await expect(run).to.be.eventually.rejectedWith(
-        'Expected not to be rejected with "Error: Test msg" but was rejected with Error: Test msg',
+      await expectEarl(run).toBeRejected(
+        expectEarl.error('Expected not to be rejected with "Error: Test msg" but was rejected with Error: Test msg'),
       )
     })
   })
@@ -39,27 +39,27 @@ describe('toBeRejected', () => {
     it('works', async () => {
       const run = earl(Promise.reject(new Error('Test msg'))).toBeRejected(earl.anything())
 
-      await expect(run).not.to.be.eventually.rejected
+      await expectEarl(run).not.toBeRejected()
     })
 
     it('works when negated', async () => {
       const run = earl(Promise.resolve()).not.toBeRejected(earl.anything())
 
-      await expect(run).not.to.eventually.rejected
+      await expectEarl(run).not.toBeRejected()
     })
 
     it('throws when shouldnt throw', async () => {
       const run = earl(Promise.reject(new Error('Test msg'))).not.toBeRejected(earl.anything())
 
-      await expect(run).to.be.eventually.rejectedWith(
-        'Expected not to be rejected with "[Anything]" but was rejected with Error: Test msg',
+      await expectEarl(run).toBeRejected(
+        expectEarl.error('Expected not to be rejected with "[Anything]" but was rejected with Error: Test msg'),
       )
     })
 
     it('throws when expected not to throw but threw', async () => {
       const run = earl(Promise.resolve()).toBeRejected(earl.anything())
 
-      await expect(run).to.be.eventually.rejectedWith("Expected to be rejected but didn't")
+      await expectEarl(run).toBeRejected(expectEarl.error("Expected to be rejected but didn't"))
     })
   })
 
@@ -67,21 +67,23 @@ describe('toBeRejected', () => {
   describe.skip('autofix', () => {
     it('calls autofix on missing values', async () => {
       const dummyAutofix = spy()
+      // const dummyAutofixEarl = mockFn<[string, any], void>();
+      // dummyAutofixEarl.expectedCall
       const e = new Expectation(dummyAutofix, Promise.reject(new Error('Goodbye cruel world!')))
 
       await e.toBeRejected()
 
       expect(dummyAutofix).to.be.calledOnce
       // grrr this is ugly, I hope we will rewrite these tests to earl soon :->
-      expect(dummyAutofix.args[0][0]).to.be.eq('toBeRejected')
-      expect(dummyAutofix.args[0][1].message).to.be.eq('Goodbye cruel world!')
+      expectEarl(dummyAutofix.args[0][0]).toEqual('toBeRejected')
+      expectEarl(dummyAutofix.args[0][1].message).toEqual('Goodbye cruel world!')
     })
 
     it('does not call autofix when expectation was provided', async () => {
       const dummyAutofix = spy()
       const e = new Expectation(dummyAutofix, Promise.resolve())
 
-      await expect(e.toBeRejected(earl.anything())).to.be.rejected
+      await expectEarl(e.toBeRejected(earl.anything())).toBeRejected()
       expect(dummyAutofix).not.to.be.called
     })
 
@@ -89,7 +91,7 @@ describe('toBeRejected', () => {
       const dummyAutofix = spy()
       const e = new Expectation(dummyAutofix, Promise.resolve())
 
-      await expect(e.toBeRejected()).to.be.rejectedWith("Expected to be rejected but didn't")
+      await expectEarl(e.toBeRejected()).toBeRejected(expectEarl.error("Expected to be rejected but didn't"))
       expect(dummyAutofix).not.to.be.called
     })
   })

--- a/test/validators/toEqual.test.ts
+++ b/test/validators/toEqual.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import sinon from 'sinon'
 
-import { expect as earl } from '../../src'
+import { expect as earl, expect as expectEarl } from '../../src'
 import { Expectation } from '../../src/Expectation'
 
 describe('toEqual', () => {
@@ -10,7 +10,7 @@ describe('toEqual', () => {
       const dummyAutofix = sinon.spy()
       const e = new Expectation(dummyAutofix, 'abc')
 
-      expect(() => e.toEqual(undefined as any)).to.throw()
+      expectEarl(() => e.toEqual(undefined as any)).toThrow(expectEarl.error('"abc" not equal to undefined'))
       expect(dummyAutofix).not.to.be.called
     })
 
@@ -56,7 +56,7 @@ describe('toEqual', () => {
     })
 
     it('throws on mismatch', () => {
-      expect(() => earl(42).toEqual(420)).to.throw('42 not equal to 420')
+      expectEarl(() => earl(42).toEqual(420)).toThrow(expectEarl.error('42 not equal to 420'))
     })
 
     describe('error messages', () => {
@@ -77,7 +77,7 @@ describe('toEqual', () => {
     })
 
     it('throws', () => {
-      expect(() => earl(5).not.toEqual(5)).to.throw('5 equal to 5')
+      expectEarl(() => earl(5).not.toEqual(5)).toThrow(expectEarl.error('5 equal to 5'))
     })
   })
 })

--- a/test/validators/toThrow.test.ts
+++ b/test/validators/toThrow.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { spy } from 'sinon'
 
-import { expect as earl } from '../../src'
+import { expect as earl, expect as expectEarl } from '../../src'
 import { Expectation } from '../../src/Expectation'
 
 describe('toThrow', () => {
@@ -16,15 +16,15 @@ describe('toThrow', () => {
 
       expect(dummyAutofix).to.be.calledOnce
       // grrr this is ugly, I hope we will rewrite these tests to earl soon :->
-      expect(dummyAutofix.args[0][0]).to.be.eq('toThrow')
-      expect(dummyAutofix.args[0][1].message).to.be.eq('Goodbye cruel world!')
+      expectEarl(dummyAutofix.args[0][0]).toEqual('toThrow')
+      expectEarl(dummyAutofix.args[0][1].message).toEqual('Goodbye cruel world!')
     })
 
     it('does not call autofix when expectation was provided', () => {
       const dummyAutofix = spy()
       const e = new Expectation(dummyAutofix, () => {})
 
-      expect(() => e.toThrow(earl.anything())).to.throw()
+      expectEarl(() => e.toThrow(earl.anything())).toThrow(expectEarl.error("Expected to throw but didn't"))
       expect(dummyAutofix).not.to.be.called
     })
 
@@ -32,7 +32,7 @@ describe('toThrow', () => {
       const dummyAutofix = spy()
       const e = new Expectation(dummyAutofix, () => {})
 
-      expect(() => e.toThrow()).to.throw("Expected to throw but didn't")
+      expectEarl(() => e.toThrow()).toThrow(expectEarl.error("Expected to throw but didn't"))
       expect(dummyAutofix).not.to.be.called
     })
   })
@@ -44,7 +44,7 @@ describe('toThrow', () => {
           throw new Error('Test msg')
         }).toThrow(earl.error('Test msg'))
 
-      expect(run).not.to.throw()
+      expectEarl(run).not.toThrow()
     })
 
     it('throws on msg mismatch', () => {
@@ -53,7 +53,7 @@ describe('toThrow', () => {
           throw new Error('Test msg')
         }).toThrow(earl.error('Dummy msg'))
 
-      expect(run).to.throw('Expected to throw "Error: Dummy msg" but threw "Error: Test msg"')
+      expectEarl(run).toThrow(expectEarl.error('Expected to throw "Error: Dummy msg" but threw "Error: Test msg"'))
     })
 
     it('works when negated', () => {
@@ -62,7 +62,7 @@ describe('toThrow', () => {
           throw new Error('Test msg')
         }).not.toThrow('Dummy msg')
 
-      expect(run).not.to.throw()
+      expectEarl(run).not.toThrow()
     })
 
     it('throws when negated and msg match', () => {
@@ -71,7 +71,7 @@ describe('toThrow', () => {
           throw new Error('Test msg')
         }).not.toThrow(earl.error('Test msg'))
 
-      expect(run).to.throw('Expected not to throw "Error: Test msg" but threw "Error: Test msg"')
+      expectEarl(run).toThrow(expectEarl.error('Expected not to throw "Error: Test msg" but threw "Error: Test msg"'))
     })
 
     it('works with partial error messages', () => {
@@ -80,7 +80,7 @@ describe('toThrow', () => {
           throw new Error('Test msg')
         }).toThrow(earl.error(earl.stringMatching('Test')))
 
-      expect(run).not.to.throw()
+      expectEarl(run).not.toThrow()
     })
 
     class HttpError extends Error {
@@ -95,7 +95,7 @@ describe('toThrow', () => {
           throw new HttpError(500)
         }).toThrow(earl.error(HttpError))
 
-      expect(run).not.to.throw()
+      expectEarl(run).not.toThrow()
     })
 
     it('works with custom error classes with error messages', () => {
@@ -104,7 +104,7 @@ describe('toThrow', () => {
           throw new HttpError(500)
         }).toThrow(earl.error(HttpError, earl.stringMatching('Http Error')))
 
-      expect(run).not.to.throw()
+      expectEarl(run).not.toThrow()
     })
 
     it('throws when error messages doesnt match', () => {
@@ -113,7 +113,7 @@ describe('toThrow', () => {
           throw new Error('500')
         }).toThrow(earl.error(HttpError))
 
-      expect(run).to.throw('Expected to throw "HttpError" but threw "Error: 500"')
+      expectEarl(run).toThrow(expectEarl.error('Expected to throw "HttpError" but threw "Error: 500"'))
     })
   })
 
@@ -124,13 +124,13 @@ describe('toThrow', () => {
           throw new Error('Test msg')
         }).toThrow(earl.anything())
 
-      expect(run).not.to.throw()
+      expectEarl(run).not.toThrow()
     })
 
     it('works when negated', () => {
       const run = () => earl(() => {}).not.toThrow(earl.anything())
 
-      expect(run).not.to.throw()
+      expectEarl(run).not.toThrow()
     })
 
     it('throws when shouldnt throw', () => {
@@ -139,13 +139,13 @@ describe('toThrow', () => {
           throw new Error('Test msg')
         }).not.toThrow(earl.anything())
 
-      expect(run).to.throw('Expected not to throw "[Anything]" but threw "Error: Test msg"')
+      expectEarl(run).toThrow(expectEarl.error('Expected not to throw "[Anything]" but threw "Error: Test msg"'))
     })
 
     it('throws when expected not to throw but threw', () => {
       const run = () => earl(() => {}).toThrow(earl.anything())
 
-      expect(run).to.throw("Expected to throw but didn't")
+      expectEarl(run).toThrow(expectEarl.error("Expected to throw but didn't"))
     })
   })
 })


### PR DESCRIPTION
This PR is a WIP because I want to do it all in one go with mocks and not have two testing libraries simultaneously.

It contains of three things:
1. Use earl in tests whenever possible (except mocks). I import it as `expectEarl` to avoid name clash. It's a temporary hack due to removal before the merge
2. Add a `build:watch:tests` script to `package.json`. Currently build:watch doesn't watch the test directory and it makes working on tests harder. Maybe the better solution is to use the debug tscongif in `build:watch`? @krzkaczor 
3. `a(Primitive)` didn't support Function type correctly, so I've added Function support to a big ternary in `Class2Primitive`. Unfortunately, I believe that TS doesn't have a primitive for Function so I've made it any. @krzkaczor any better solutions?

Also - It's kinda cumbersome to have to write earl.error("Actual error") everywhere in tests. We should do some magic about it.

Either way - this think is up for discussions. I think we need to add some more functionality to loose mocks before they're usable and only after this could be merged.
